### PR TITLE
fix default cert display (no error necessary)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/brc100-ui-react-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/brc100-ui-react-components",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/uhrp-react": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/brc100-ui-react-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/pages/Dashboard/CertificateAccess/index.tsx
+++ b/src/pages/Dashboard/CertificateAccess/index.tsx
@@ -65,6 +65,18 @@ const CertificateAccess: React.FC = () => {
           registryOperators,
         })
 
+        if (results.length === 0) {
+          const placeholderDef: CertificateDefinition = {
+            name: "Custom Certificate",
+            iconURL: DEFAULT_APP_ICON,
+            description: 'This certificate type has not yet been registered by anyone in your Certifier Network.',
+            documentationURL: 'https://docs.bsvblockchain.org/',
+            fields: {}
+          };
+          setCertDefinition(placeholderDef);
+          return;
+        }
+
         let mostTrustedIndex = 0
         let maxTrustedPoints = 0
         for(let i = 0; i < results.length; i++){
@@ -192,20 +204,18 @@ const CertificateAccess: React.FC = () => {
           })}
         </Box>
       </Grid>
-      <Grid item>
+      {/* <Grid item>
         <Typography variant='h4'>Issued Certificates</Typography>
-        {/* --- CertificateAccessList Placeholder --- */}
         <Box sx={{ mt: 1, p: 2, border: '1px dashed grey', borderRadius: 1, textAlign: 'center' }}>
           <Typography color="textSecondary">CertificateAccessList component needs to be created/refactored.</Typography>
-          {/* <CertificateAccessList
+          <CertificateAccessList
             itemsDisplayed='apps' // Or 'counterparties'?
             canRevoke
             clickable={false}
             type={certType}
-          /> */}
+          />
         </Box>
-        {/* --- End Placeholder --- */}
-      </Grid>
+      </Grid> */}
       {/* Removed ProtocolPermissionList as it seemed out of place here */}
     </Grid>
   );

--- a/src/pages/Dashboard/MyIdentity/CertificateCard.tsx
+++ b/src/pages/Dashboard/MyIdentity/CertificateCard.tsx
@@ -47,7 +47,7 @@ const CertificateCard: React.FC<CertificateCardProps> = ({
   onRevoke
 }) => {
   const history = useHistory()
-  const [certName, setCertName] = useState<string>('Unknown Cert')
+  const [certName, setCertName] = useState<string>('Custom Certificate')
   const [iconURL, setIconURL] = useState<string>(DEFAULT_APP_ICON)
   const [description, setDescription] = useState<string>('')
   const [fields, setFields] = useState<{ [key: string]: CertificateFieldDescriptor }>({})
@@ -321,9 +321,6 @@ const CertificateDetailsModal: React.FC<CertificateDetailsModalProps> = ({
                 </Box>
               ) : (
                 <div style={{ display: 'flex' }}>
-                  <Typography variant="body1" paddingRight="0.5em">
-                    Value:
-                  </Typography>
                   <Typography variant="h5">{value.value}</Typography>
                 </div>
               )}


### PR DESCRIPTION
## Description of Changes

Stop the UI from erroring when there is an unregistered certificate being looked at.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged